### PR TITLE
Fix keycloak attributes

### DIFF
--- a/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
+++ b/engine/src/main/java/com/arcadedb/database/DocumentValidator.java
@@ -30,6 +30,7 @@ import com.arcadedb.serializer.json.JSONObject;
 
 import java.math.*;
 import java.util.*;
+import java.util.logging.Level;
 
 /**
  * Validates documents against constraints defined in the schema.
@@ -148,30 +149,35 @@ public class DocumentValidator {
     propNames.remove(Utils.LAST_MODIFIED_DATE);
 
     var numProps = propNames.size();
+    LogManager.instance().log(DocumentValidator.class, Level.INFO, "Validating document attribute classifications: " + attributes);
+    attributes.toMap().forEach((attribute, value) -> {
 
-    attributes.toMap().entrySet().forEach(entry -> {
-      var key = entry.getKey();
-
-      // validate valid key
-      if (!document.has(key)) {
-        throw new ValidationException("Invalid attribute key: " + key);
-      }
-
-      var value = entry.getValue().toString();
-
-      if (value != null && value.trim() != "") {
-
-        verifyDocumentClassificationValidForDeployment(value, document.getDatabase().getSchema().getEmbedded().getClassification());
-
-        var inputIndex = AuthorizationUtils.classificationOptions.get(value);
-        var userClearanceIndex = AuthorizationUtils.classificationOptions.get(securityDatabaseUser.getClearanceForCountryOrTetragraphCode("USA"));
-
-        if (inputIndex > userClearanceIndex) {
-          throw new ValidationException("User cannot set attribute classification markings on documents higher than or outside their current access.");
+        // validate valid key
+        if (!document.has(attribute)) {
+            throw new ValidationException("Invalid attribute key: " + attribute);
         }
-      } else {
-        throw new ValidationException("Invalid attribute classification marking for: " + key);
-      }
+
+        var attributeClassification = value.toString();
+
+        if (attributeClassification != null && !attributeClassification.trim().isEmpty()) {
+            // This call might not be necessary after integrating with df-classification.
+            verifyDocumentClassificationValidForDeployment(
+                    attributeClassification,
+                    document.getDatabase().getSchema().getEmbedded().getClassification());
+
+            // Taking the attribute's classification value and fetching its numerical representation.
+            var inputIndex = AuthorizationUtils.classificationOptions.get(attributeClassification);
+            var userClearance = securityDatabaseUser.getClearanceForCountryOrTetragraphCode("USA");
+            var userClearanceIndex = AuthorizationUtils.classificationOptions.get(userClearance);
+
+            if (inputIndex > userClearanceIndex) {
+                throw new ValidationException(
+                        "User cannot set attribute classification markings on documents higher than or outside their current access!" +
+                                " User clearance is " + userClearance + " but attribute classification was " + attributeClassification);
+            }
+        } else {
+            throw new ValidationException("Invalid attribute classification marking for: " + attribute);
+        }
     });
 
     if (attributes.length() < numProps) {

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurity.java
@@ -390,7 +390,7 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
     List<ArcadeRole> arcadeRoles = getArcadeRolesFromString(result.getRoles());
     userArcadeRoles.put(username, arcadeRoles);
 
-    log.info("getOrCreateuser - parsed arcade roles {}", arcadeRoles);
+    log.info("getOrCreateUser - parsed arcade roles {}", arcadeRoles);
 
     // 3. Convert arcade roles to groups
     List<Group> neededGroups = arcadeRoles.stream()
@@ -439,6 +439,7 @@ public class ServerSecurity implements ServerPlugin, com.arcadedb.security.Secur
 
     // 6. get user attribtues for ACCM
     Map<String, Object> attributes = result.getAttributes();
+    log.debug("OPA policy attributes are " + attributes);
 
     ServerSecurityUser serverSecurityUser = new ServerSecurityUser(server, userJson, arcadeRoles, attributes, 
             System.currentTimeMillis(), result.getPolicy());

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -347,11 +347,11 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   }
 
   public String getClearanceForCountryOrTetragraphCode(String code) {
-    return getStringValueFromKeycloakAttribute("classification");
+    return getStringValueFromKeycloakAttribute("clearance");
   }
 
   public String getNationality() {
-    return getStringValueFromKeycloakAttribute("country");
+    return getStringValueFromKeycloakAttribute("nationality");
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -20,6 +20,7 @@ package com.arcadedb.server.security;
 
 import com.arcadedb.database.DatabaseInternal;
 import com.arcadedb.engine.ComponentFile;
+import com.arcadedb.log.LogManager;
 import com.arcadedb.schema.DocumentType;
 import com.arcadedb.security.SecurityDatabaseUser;
 import com.arcadedb.security.SecurityManager;
@@ -32,6 +33,7 @@ import com.arcadedb.security.serializers.OpaPolicy;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
+import java.util.logging.Level;
 
 @Slf4j
 public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
@@ -347,17 +349,30 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   }
 
   public String getClearanceForCountryOrTetragraphCode(String code) {
-    return getStringValueFromKeycloakAttribute("clearance");
+    /* TODO: implement clearances from other countries. Since we only support
+        USA clearances at the moment, this just returns the user's clearance level from keycloak. */
+    return getStringValueFromKeycloakAttribute("classification");
   }
 
   public String getNationality() {
-    return getStringValueFromKeycloakAttribute("nationality");
+    // Checks for two keycloak attributes that can be evaluated to determine nationality
+    String nationality = getStringValueFromKeycloakAttribute("country");
+    boolean citizenOfCountry =
+            Objects.requireNonNullElse(
+                    getStringValueFromKeycloakAttribute("citizenship"), "N")
+                    .equalsIgnoreCase("Y");
+
+    if (!citizenOfCountry) {
+        throw new RuntimeException("Unknown user nationality!");
+    }
+    return nationality;
   }
 
   /**
    * Checks if the user has the specific Tetragraph, or 4 character code representing an organization, like NATO, etc.
    */
   public boolean hasTetragraph(String tetraGraph) {
+    // TODO: This KC attribute does not exist yet. Needs implementation.
     String tetras = getStringValueFromKeycloakAttribute("tetragraphs");
     if (tetras != null) {
       return tetras.contains(tetraGraph);
@@ -370,6 +385,7 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
    * Gets any Tetragraphs, or 4 character codes representing organizations, like NATO, etc. that the user may be a member of.
    */
   public String getTetragraphs() {
+    // TODO: This KC attribute does not exist yet. Needs implementation.
     return getStringValueFromKeycloakAttribute("tetragraphs");
   }
 
@@ -385,11 +401,12 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
    * @return
    */
   private String getStringValueFromKeycloakAttribute(String attributeName) {
+    LogManager.instance().log(ServerSecurityDatabaseUser.class, Level.INFO, "Keycloak attributes are " + attributes);
     if (attributes != null && attributes.containsKey(attributeName)) {
-      var nationality = attributes.get(attributeName).toString();
-      nationality = nationality.replace("[", "");
-      nationality = nationality.replace("]", "");
-      return nationality;
+      var atrribute = attributes.get(attributeName).toString();
+      atrribute = atrribute.replace("[", "");
+      atrribute = atrribute.replace("]", "");
+      return atrribute;
     } else { 
       return null;
     }

--- a/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
+++ b/server/src/main/java/com/arcadedb/server/security/ServerSecurityDatabaseUser.java
@@ -347,11 +347,11 @@ public class ServerSecurityDatabaseUser implements SecurityDatabaseUser {
   }
 
   public String getClearanceForCountryOrTetragraphCode(String code) {
-    return getStringValueFromKeycloakAttribute("clearance" + "_" + code.toLowerCase());
+    return getStringValueFromKeycloakAttribute("classification");
   }
 
   public String getNationality() {
-    return getStringValueFromKeycloakAttribute("nationality");
+    return getStringValueFromKeycloakAttribute("country");
   }
 
   /**

--- a/server/src/main/java/com/arcadedb/server/security/oidc/OpaClient.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/OpaClient.java
@@ -56,7 +56,7 @@ public class OpaClient extends DataFabricRestClient {
         // TODO make configurable
         var possibleClassifications = new String[] { "U", "C", "S", "TS" };
 
-        var clearance = responseJson.get("classification").asText();
+        var clearance = responseJson.get("clearance").asText();
 
         List<String> authorizedClassificationsList = new ArrayList<>();
         for (String classification : possibleClassifications) {
@@ -71,7 +71,7 @@ public class OpaClient extends DataFabricRestClient {
         // relto
         List<String> relTo = new ArrayList<>(); // TODO Arrays.asList(responseJson.get("releasable_to").asText().split(","));
 
-        String nationality = responseJson.get("country").asText();
+        String nationality = responseJson.get("nationality").asText();
         var hasAccessToFvey = responseJson.has(FVEY) ? responseJson.get(FVEY).asBoolean() : false;
         var hasAccessToAcgu = responseJson.has(ACGU) ? responseJson.get(ACGU).asBoolean() : false;
 

--- a/server/src/main/java/com/arcadedb/server/security/oidc/OpaClient.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/OpaClient.java
@@ -38,8 +38,6 @@ public class OpaClient extends DataFabricRestClient {
     public static OpaResponse getPolicy(String username, Set<String> databaseNames) {
         var policyResponseString = sendAuthenticatedPostAndGetResponse(getBaseOpaUrl(), username);
 
-        LogManager.instance().log(OpaClient.class, Level.INFO, "policy response string: " + policyResponseString);
-
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode responseJson = null;
 
@@ -48,10 +46,11 @@ public class OpaClient extends DataFabricRestClient {
             responseJson = objectMapper.readTree(policyResponseString);
             responseJson = responseJson.get("result");
         } catch (JsonProcessingException e) {
-            LogManager.instance().log(OpaClient.class, Level.SEVERE, "Error parsing JSON response from OPA");
-            e.printStackTrace();
+            LogManager.instance().log(OpaClient.class, Level.SEVERE, "Error parsing JSON response from OPA.");
             return null;
         }
+
+        LogManager.instance().log(OpaClient.class, Level.INFO, "OPA policy response: " + responseJson.toPrettyString());
 
         // TODO make configurable
         var possibleClassifications = new String[] { "U", "C", "S", "TS" };

--- a/server/src/main/java/com/arcadedb/server/security/oidc/OpaClient.java
+++ b/server/src/main/java/com/arcadedb/server/security/oidc/OpaClient.java
@@ -56,7 +56,7 @@ public class OpaClient extends DataFabricRestClient {
         // TODO make configurable
         var possibleClassifications = new String[] { "U", "C", "S", "TS" };
 
-        var clearance = responseJson.get("clearance_usa").asText();
+        var clearance = responseJson.get("classification").asText();
 
         List<String> authorizedClassificationsList = new ArrayList<>();
         for (String classification : possibleClassifications) {
@@ -71,7 +71,7 @@ public class OpaClient extends DataFabricRestClient {
         // relto
         List<String> relTo = new ArrayList<>(); // TODO Arrays.asList(responseJson.get("releasable_to").asText().split(","));
 
-        String nationality = responseJson.get("nationality").asText();
+        String nationality = responseJson.get("country").asText();
         var hasAccessToFvey = responseJson.has(FVEY) ? responseJson.get(FVEY).asBoolean() : false;
         var hasAccessToAcgu = responseJson.has(ACGU) ? responseJson.get(ACGU).asBoolean() : false;
 


### PR DESCRIPTION
## What does this PR do?
Key cloak attributes were updated in [this PR](https://github.com/raft-tech/data-fabric/pull/3802/files). Arcade was referencing some of those changed attributes and those references need to be updating.

Aside from those changes, I added some logging that help with debugging and stepping through the authorization code. I also changed some variable names to help me remember what I was looking at.

## Testing
1. Create a new data fabric cluster from [this branch](https://github.com/raft-tech/data-fabric/tree/fix-keycloak-attributes), which creates the _correct_ default keycloak attributes for the admin user.
2. Once the cluster comes up, run `make kind` from this branch of `df-arcadedb` and change the arcade deployment's image tag to `dev`. 
3. Create a database:
```shell    
TOKEN=$(dfdev auth token | tr -d '\n' ) \
  && http post :/api/v1/arcadedb/server "Authorization: Bearer ${TOKEN}" \
  < create_secret_database.json
```
4. Create a new vertex
```shell
TOKEN=$(dfdev auth token | tr -d '\n' ) \
  && http post :/api/v1/arcadedb/command/secret_people "Authorization: Bearer ${TOKEN}" \
  < create_people_vertex.json
```
5. Login to the arcadedb UI and try to save this:
```
INSERT INTO People CONTENT
{
  firstName: 'Enzo2',
  lastName: 'Ferrari',
  classification:{
  	components: {
    	classification: 'S',
        disseminationControls: ['REL'],
        releasableTo: ['USA', 'FVEY'],
        ownerProducer: ['USA']
    },
    attributes:{
    	firstName: 'U',
        lastName: 'U'
    }
  }
 }
```
