### PR TITLE
disable cdc

### DIFF
--- a/server/src/main/java/com/arcadedb/server/kafka/KafkaEventListener.java
+++ b/server/src/main/java/com/arcadedb/server/kafka/KafkaEventListener.java
@@ -38,27 +38,27 @@ public class KafkaEventListener implements AfterRecordCreateListener, AfterRecor
          */
         this.databaseUsername = databaseUsername == null ? "admin" : databaseUsername;
 
-        this.client.createTopicIfNotExists(this.client.getTopicNameForDatabase(this.databaseName, this.databaseUsername));
+    //    this.client.createTopicIfNotExists(this.client.getTopicNameForDatabase(this.databaseName, this.databaseUsername));
     }
 
     @Override
     public void onAfterCreate(Record record) {
-        Message message = KafkaRecordUtil.createMessage(RecordEvents.AFTER_RECORD_CREATE, record);
+    //    Message message = KafkaRecordUtil.createMessage(RecordEvents.AFTER_RECORD_CREATE, record);
 
-        this.client.sendMessage(this.databaseName, this.databaseUsername, message);
+    //    this.client.sendMessage(this.databaseName, this.databaseUsername, message);
     }
 
     @Override
     public void onAfterDelete(Record record) {
-        Message message = KafkaRecordUtil.createMessage(RecordEvents.AFTER_RECORD_DELETE, record);
+    //    Message message = KafkaRecordUtil.createMessage(RecordEvents.AFTER_RECORD_DELETE, record);
 
-        this.client.sendMessage(this.databaseName, this.databaseUsername, message);
+    //    this.client.sendMessage(this.databaseName, this.databaseUsername, message);
     }
 
     @Override
     public void onAfterUpdate(Record record) {
-        Message message = KafkaRecordUtil.createMessage(RecordEvents.AFTER_RECORD_UPDATE, record);
+    //    Message message = KafkaRecordUtil.createMessage(RecordEvents.AFTER_RECORD_UPDATE, record);
 
-        this.client.sendMessage(this.databaseName, this.databaseUsername, message);
+    //    this.client.sendMessage(this.databaseName, this.databaseUsername, message);
     }
 }


### PR DESCRIPTION
# Overview

> _Describe your changes.  This can also be the commit message (if it was a [good one](https://cbea.ms/git-commit/))._

# Test Procedure

## Setup

From a new shell session in any clean/empty directory, perform the following 👇.

### Environment

1. Export your GitHub credentials to pull from the GitHub container registry.
    ```shell
    export GHP_USERNAME=your_github_username_goes_here
    export GHP_SECRET=your_github_pat_goes_here
    ```

1. Create a subdirectory for this PR test.
    ```shell
    export PR_HOME=$(pwd)/pr-test
    mkdir -pv $PR_HOME
    ```

### Clone Repositories

1. Clone the main `data-fabric` repo, checking out the branch we'll use to test this PR.
    ```shell
    export DF_HOME=$PR_HOME/data-fabric
    git clone --branch dev https://github.com/raft-tech/data-fabric.git $DF_HOME
    ```

1. Clone the `df-arcadedb`, checking out the branch for this PR.
    ```shell
    export DF_ARCADEDB_HOME=$PR_HOME/df-arcadedb    
    git clone --branch YOUR_PR_BRANCH https://github.com/raft-tech/df-arcadedb.git $DF_ARCADEDB_HOME
    ```

1. Clone `dfdev` to help with building and running things. \
   ℹ️ _If you already have [`dfdev`](https://github.com/raft-tech/dfdev) you can skip this step._
    ```shell
    git clone https://github.com/raft-tech/dfdev.git $PR_HOME/dfdev
    PATH=$PATH:$PR_HOME/dfdev/dfdev
    ```
   
### Deploy

1. (Re)Create a new local `kind` cluster and deploy Data Fabric to it.
    ```shell
    dfdev cluster recreate
    ```

1. Re-build and re-deploy `df-arcadedb`

    ```shell
    dfdev redeploy df-arcadedb
    ``` 

## Verification Steps

1. Do this
Copy a graphson test data file into the arcade pod like the following. Update your pod name.
```
kubectl cp ./all.graphson data-fabric/df-arcadedb-77f7d9896d-p59v8:/tmp -c arcadedb
```

2. Create a database in arcade called `mm_test`. Uncheck the last checkbox on the modal.

3. Grab an auth token and replace in the following command. Run from within the container.
```
curl -v  \
-H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJvOG0tNk1xeHBsTDhmN1Zod2g2WW11TV96bDdSbnZQTi1zVmRrQnE2NmRVIn0.eyJleHAiOjE3Mjc3MjY2NjMsImlhdCI6MTcyNzcyNTc2MywianRpIjoiZDA4MTQ0ZjQtOTcyNi00NzBmLThkNTYtYTE0NDAwYTYzZTVhIiwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3QvYXV0aC9yZWFsbXMvZGF0YS1mYWJyaWMiLCJhdWQiOlsicmVhbG0tbWFuYWdlbWVudCIsImRmLXN1cGVyc2V0IiwiYWNjb3VudCJdLCJzdWIiOiIyYzZlNjEyMC1iM2M3LTQ1N2QtOTU5Yi1kNzIyMzE0OTY3NmUiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJkZi1iYWNrZW5kIiwic2Vzc2lvbl9zdGF0ZSI6IjdmNDJmNjMyLWFlZmMtNGU5NC04YWJlLTdlOWRhZjlhNTI2ZSIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiLyoiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImVuYWJsZXIiLCJvZmZsaW5lX2FjY2VzcyIsImFkbWluIiwidW1hX2F1dGhvcml6YXRpb24iLCJkZWZhdWx0LXJvbGVzLWRhdGEtZmFicmljIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsicmVhbG0tbWFuYWdlbWVudCI6eyJyb2xlcyI6WyJ2aWV3LXJlYWxtIiwidmlldy1pZGVudGl0eS1wcm92aWRlcnMiLCJtYW5hZ2UtaWRlbnRpdHktcHJvdmlkZXJzIiwiaW1wZXJzb25hdGlvbiIsInJlYWxtLWFkbWluIiwiY3JlYXRlLWNsaWVudCIsIm1hbmFnZS11c2VycyIsInF1ZXJ5LXJlYWxtcyIsInZpZXctYXV0aG9yaXphdGlvbiIsInF1ZXJ5LWNsaWVudHMiLCJxdWVyeS11c2VycyIsIm1hbmFnZS1ldmVudHMiLCJtYW5hZ2UtcmVhbG0iLCJ2aWV3LWV2ZW50cyIsInZpZXctdXNlcnMiLCJ2aWV3LWNsaWVudHMiLCJtYW5hZ2UtYXV0aG9yaXphdGlvbiIsIm1hbmFnZS1jbGllbnRzIiwicXVlcnktZ3JvdXBzIl19LCJkZi1zdXBlcnNldCI6eyJyb2xlcyI6WyJBZG1pbiJdfSwiZGYtYmFja2VuZCI6eyJyb2xlcyI6WyJtaW5pby0tZGYtYnVja2V0LS1DUlVETE0iLCJhcmNhZGVfX2RhdGFTdGV3YXJkX19kLSpfX3QtKiIsIm1pbmlvLS0qLS0qIiwiYXJjYWRlX191c2VyX19kLSpfX3QtKl9fcC1DUlVEIiwiYXJjYWRlX19zYV9fKiIsIm1pbmlvLS1pbmJveC1wdWJsaWMtLUNSTCIsIm1pbmlvLS1pbmJveC1wdWJsaWMtLSoiLCJhcmNhZGVfX2RiYV9fZC0qX18qIiwiaW5mb3JtYXRpb24tZGlzY2xvc3VyZS1vZmZpY2lhbCJdfSwiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSBlbWFpbCIsInNpZCI6IjdmNDJmNjMyLWFlZmMtNGU5NC04YWJlLTdlOWRhZjlhNTI2ZSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZ3JvdXBzIjpbIkFkbWluIiwiQXJjYWRlIEFkbWluIiwiRGF0YSBTdGV3YXJkIEFkbWluIiwiSW5mb3JtYXRpb24gRGlzY2xvc3VyZSBPZmZpY2lhbCIsIlB1YmxpYyIsIlB1YmxpYyBBZG1pbiJdLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiJ9.dLm90gTQliL_U9oFT7g6eCuQapV5MoDOIkQ1pjSGEnpLaK9cig5AcHxdczvTa_qfavsctZKOStSl-Zor0wGMKWyoumuOeayWwojlAo17Wq9MK_zCfdJZm54y0f4KXF9ARV1kAlRXfqTns8CGjKr8gpr1iKcMQfscwROgOy1rd_oqd34-J8LpE-2vkgCqc7IGiRS5XR2vKwFgvnPbuasePHGfPG9M6IkvJ7orWzZxsD3DayDBvgBv0pPxxTl5Qvl25oyUGaJ2bgBcEIyCyNWI9UsGuPo_IFmnrCPtG2Cq2SaBM0d2ep1iRhv0uCHyqj6NRqShsL625iN6RchCouBt" \
-H "Content-type: application/json" \
-X POST "http://localhost:2480/api/v1/arcadedb/command/mm_test" \
-d '{"language":"sqlscript","command": "import database file:///tmp/all.graphson","options":{"classification":"U","owner":"me","visiblity":"some","classificationValidationEnabled":"false","importOntology":"false"}}'
```

4. Confirm the command succeeds

5. Confirm data in arcade. Switch query language to gremlin. Run `g.V()`. Confirm data shows.